### PR TITLE
Added bytes specifier to "Not Found" strings for Python 3 compatibility.

### DIFF
--- a/rednoise/base.py
+++ b/rednoise/base.py
@@ -114,7 +114,7 @@ class DjangoRedNoise(DjangoWhiteNoise):
                 return self.serve(asset, environ, start_response)
             else:
                 start_response(A404, [('Content-Type', 'text/plain')])
-                return ['Not Found']
+                return [b'Not Found']
 
         if self.should_serve_media and self.is_media(path):
             asset = self.load_media_file(path)
@@ -122,7 +122,7 @@ class DjangoRedNoise(DjangoWhiteNoise):
                 return self.serve(asset, environ, start_response)
             else:
                 start_response(A404, [('Content-Type', 'text/plain')])
-                return ['Not Found']
+                return [b'Not Found']
 
         return self.application(environ, start_response)
 


### PR DESCRIPTION
My Django project under Python 3 was throwing the error below, which only seems to happen with the hard-coded static links, 'favicon.co' in this instance.

```
[22/Oct/2015 09:51:16] "GET /static/favicon.ico HTTP/1.1" 404 0
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/wsgiref/handlers.py", line 138, in run
    self.finish_response()
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/wsgiref/handlers.py", line 180, in finish_response
    self.write(data)
  File "/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/wsgiref/handlers.py", line 266, in write
    "write() argument must be a bytes instance"
AssertionError: write() argument must be a bytes instance
```
